### PR TITLE
Wait for resource and connectors to be ready

### DIFF
--- a/.changelog/20.txt
+++ b/.changelog/20.txt
@@ -1,0 +1,5 @@
+```release-note:enhancement
+Enable state monitoring for connector and resource resources.
+Resource creation will error after 10 minutes timeout if the desired
+state has not been reached.
+```

--- a/meroxa/resource_connector_test.go
+++ b/meroxa/resource_connector_test.go
@@ -43,6 +43,7 @@ func TestAccMeroxaConnector_basic(t *testing.T) {
 					testAccCheckMeroxaResourceExists("meroxa_connector.basic"),
 					resource.TestCheckResourceAttr("meroxa_connector.basic", "name", "connector-basic"),
 					resource.TestCheckResourceAttr("meroxa_connector.basic", "type", "jdbc-source"),
+					resource.TestCheckResourceAttr("meroxa_connector.basic", "state", "running"),
 				),
 			},
 		},

--- a/meroxa/resource_resource_test.go
+++ b/meroxa/resource_resource_test.go
@@ -71,6 +71,7 @@ func TestAccMeroxaResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("meroxa_resource.basic", "name", "resource-basic"),
 					resource.TestCheckResourceAttr("meroxa_resource.basic", "type", "postgres"),
 					resource.TestCheckResourceAttr("meroxa_resource.basic", "url", postgresqlURL),
+					resource.TestCheckResourceAttr("meroxa_resource.basic", "status", "ready"),
 				),
 			},
 		},
@@ -97,6 +98,7 @@ func TestAccMeroxaResource_inline(t *testing.T) {
 					resource.TestCheckResourceAttr("meroxa_resource.inline", "name", "inline"),
 					resource.TestCheckResourceAttr("meroxa_resource.inline", "type", "postgres"),
 					resource.TestCheckResourceAttr("meroxa_resource.inline", "url", postgresqlURL),
+					resource.TestCheckResourceAttr("meroxa_resource.inline", "status", "ready"),
 				),
 			},
 		},
@@ -104,7 +106,7 @@ func TestAccMeroxaResource_inline(t *testing.T) {
 }
 
 func TestAccMeroxaResource_sshTunnel(t *testing.T) {
-	bastionAddr := fmt.Sprintf("%s@%s", Config.BastionUser, Config.BastionHost)
+	bastionAddr := fmt.Sprintf("%s@%s:22", Config.BastionUser, Config.BastionHost)
 	privatePostgresURL, err := URLWithoutCredentials(Config.PrivatePostgresURL)
 	if err != nil {
 		t.Error(err)
@@ -149,6 +151,7 @@ func TestAccMeroxaResource_sshTunnel(t *testing.T) {
 					resource.TestCheckResourceAttr("meroxa_resource.with_tunnel", "name", "with_ssh_tunnel"),
 					resource.TestCheckResourceAttr("meroxa_resource.with_tunnel", "type", "postgres"),
 					resource.TestCheckResourceAttr("meroxa_resource.with_tunnel", "url", privatePostgresURL),
+					resource.TestCheckResourceAttr("meroxa_resource.with_tunnel", "status", "ready"),
 					resource.TestCheckResourceAttr("meroxa_resource.with_tunnel", "ssh_tunnel.0.address", bastionAddr),
 					resource.TestCheckResourceAttr("meroxa_resource.with_tunnel", "ssh_tunnel.0.public_key", sshPubKey),
 				),


### PR DESCRIPTION
Add functionality to monitor resource state change until they become ready.
Resources without SSH tunnel are created synchronously and will transition to
ready almost immediately, in contrast those with SSH tunnels will go through sligtly
longer validation process and may not be available when the connector is created.

Similarly for connector resources, creation will be completed once they transition
to ready state.

Fixes https://github.com/meroxa/product/issues/163
Fixes https://github.com/meroxa/product/issues/164