### PR TITLE
Update registry docs for getting access token

### DIFF
--- a/.changelog/30.txt
+++ b/.changelog/30.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Updated Terraform Registry docs regarding access tokens.
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,3 @@
-## v1.5.0
-
-ENHANCEMENTS:
-
-* Updating for latest meroxa-go interface; no longer exposing Connector and Pipeline metadata. ([#26](https://github.com/meroxa/terraform-provider-meroxa/issues/26))
-
-BUG FIXES:
-
-* Add connector name validation ([#29](https://github.com/meroxa/terraform-provider-meroxa/issues/29))
-
 ## v1.4.0
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENTS:
 
-* Updating for latest meroxa-go interface; no longer exposing Connector and Pipeline metadata. ([#26]https://github.com/meroxa/terraform-provider-meroxa/issues/26))
+* Updating for latest meroxa-go interface; no longer exposing Connector and Pipeline metadata. ([#26](https://github.com/meroxa/terraform-provider-meroxa/issues/26))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v1.5.0
+
+ENHANCEMENTS:
+
+* Updating for latest meroxa-go interface; no longer exposing Connector and Pipeline metadata. ([#26]https://github.com/meroxa/terraform-provider-meroxa/issues/26))
+
+BUG FIXES:
+
+* Add connector name validation ([#29](https://github.com/meroxa/terraform-provider-meroxa/issues/29))
+
 ## v1.4.0
 
 ENHANCEMENTS:

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,18 +9,32 @@ description: |-
 
 The Meroxa provider provides resources to interact with the Meroxa platform API.
 
-Get `access_token` and `refresh_token` by loggin into the Meroxa CLI.
+Get `access_token` by logging into the Meroxa CLI with `meroxa login` and running `meroxa config --json`. The output will contain `access_token` within the `config` key.
 
 Mac
 ```bash
-meroxa login
-$(awk '{print "export MEROXA_" $0}' /Users/$USER/Library/ApplicationSupport/meroxa/config.env | xargs)
+meroxa config --json
+
+{
+	"path": "/Users/$USER/Library/Application Support/meroxa/config.env",
+	"config": {
+		"access_token": $ACCESS_TOKEN,
+		...
+	}
+}
 ```
 
 Linux
 ```bash
-meroxa login
-$(awk '{print "export MEROXA_" $0}' ~/meroxa/config.env | xargs)
+meroxa config --json
+
+{
+	"path": "~/meroxa/config.env ",
+	"config": {
+		"access_token": $ACCESS_TOKEN,
+		...
+	}
+}
 ```
 
 ## Example Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ meroxa config --json
 	"path": "/Users/$USER/Library/Application Support/meroxa/config.env",
 	"config": {
 		"access_token": $ACCESS_TOKEN,
+		"refresh_token": $REFRESH_TOKEN,
 		...
 	}
 }
@@ -32,9 +33,16 @@ meroxa config --json
 	"path": "~/meroxa/config.env ",
 	"config": {
 		"access_token": $ACCESS_TOKEN,
+		"refresh_token": $REFRESH_TOKEN,
 		...
 	}
 }
+```
+
+If you prefer to set env vars for `access_token` and `refresh_token`:
+```
+export MEROXA_ACCESS_TOKEN=$(meroxa config --json | jq -r .config.access_token)
+export MEROXA_REFRESH_TOKEN=$(meroxa config --json | jq -r .config.refresh_token)
 ```
 
 ## Example Usage

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -9,18 +9,32 @@ description: |-
 
 The Meroxa provider provides resources to interact with the Meroxa platform API.
 
-Get `access_token` and `refresh_token` by loggin into the Meroxa CLI.
+Get `access_token` by logging into the Meroxa CLI with `meroxa login` and running `meroxa config --json`. The output will contain `access_token` within the `config` key.
 
 Mac
 ```bash
-meroxa login
-$(awk '{print "export MEROXA_" $0}' /Users/$USER/Library/ApplicationSupport/meroxa/config.env | xargs)
+meroxa config --json
+
+{
+	"path": "/Users/$USER/Library/Application Support/meroxa/config.env",
+	"config": {
+		"access_token": $ACCESS_TOKEN,
+		...
+	}
+}
 ```
 
 Linux
 ```bash
-meroxa login
-$(awk '{print "export MEROXA_" $0}' ~/meroxa/config.env | xargs)
+meroxa config --json
+
+{
+	"path": "~/meroxa/config.env ",
+	"config": {
+		"access_token": $ACCESS_TOKEN,
+		...
+	}
+}
 ```
 
 ## Example Usage


### PR DESCRIPTION
# Description of change

Updates the Terraform Registry docs on grabbing the `access_token` from the Meroxa CLI.

# Type of change
- [x]  Bug fix

# How was this tested?
Markdown preview, and running these commands on my local machine 😄 